### PR TITLE
included the plone.behavior meta.zcml file

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,5 +4,8 @@ Changelog
  (unreleased)
 ------------------
 
+- included the plone.behavior meta.zcml file,
+  so that we get access to the <plone:behavior /> ZCML directive.
+  [bogdangi]
 - work with plone:master p.a.portlets  
   [tmog]

--- a/collective/portlet/carousel/configure.zcml
+++ b/collective/portlet/carousel/configure.zcml
@@ -7,6 +7,8 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     i18n_domain="collective.portlet.carousel">
 
+    <include package="plone.behavior" file="meta.zcml" />
+
     <five:registerPackage
         package="."
         initialize=".initialize"


### PR DESCRIPTION
I have got error when try use it with my tests:

```
ConfigurationError: ('Unknown directive', u'http://namespaces.plone.org/plone', u'behavior') 
```

I found that it can happen because of "meta.zcml"
