### PR TITLE
Fix to use widgets from plone.app.widgets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Features:
 - add option to set timeout in portlet.
   [tmog]
 
+- add new widgets from plone.app.widgets
+  [datakurre]
+
 Fixes:
 
 - only do rotation if we have more

--- a/collective/portlet/carousel/__init__.py
+++ b/collective/portlet/carousel/__init__.py
@@ -1,2 +1,0 @@
-def initialize(context):
-    """Initializer called when used as a Zope 2 product."""

--- a/collective/portlet/carousel/configure.zcml
+++ b/collective/portlet/carousel/configure.zcml
@@ -1,6 +1,6 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:five="http://namespaces.zope.org/five"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:plone="http://namespaces.plone.org/plone"
     xmlns:browser="http://namespaces.zope.org/browser"
@@ -8,11 +8,6 @@
     i18n_domain="collective.portlet.carousel">
 
     <include package="plone.behavior" file="meta.zcml" />
-
-    <five:registerPackage
-        package="."
-        initialize=".initialize"
-        />
 
     <includeDependencies
         package="."
@@ -66,5 +61,24 @@
         permission="zope.Public"
         />
 
+    <adapter
+        factory=".widgets.CarouselBackgroundLinkWidget"
+        zcml:condition="installed plone.app.widgets"
+        />
+
+    <adapter
+        factory=".widgets.CarouselLinkWidget"
+        zcml:condition="installed plone.app.widgets"
+        />
+
+    <adapter
+        factory=".widgets.CarouselCollectionReferenceWidget"
+        zcml:condition="installed plone.app.widgets"
+        />
+
+    <adapter
+        factory=".widgets.CarouselReferencesWidget"
+        zcml:condition="installed plone.app.widgets"
+        />
 
 </configure>

--- a/collective/portlet/carousel/widgets.py
+++ b/collective/portlet/carousel/widgets.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from collective.portlet.carousel.interfaces import ICarouselItemBehavior
+from collective.portlet.carousel.interfaces import ICarouselPortlet
+from plone.app.widgets.dx import RelatedItemsWidget
+from plone.app.widgets.interfaces import IWidgetsLayer
+from z3c.form.interfaces import IFieldWidget
+from z3c.form.util import getSpecification
+from z3c.form.widget import FieldWidget
+from zope.component import adapter
+from zope.interface import implementer
+
+
+@adapter(getSpecification(ICarouselItemBehavior['carousel_background_link']),  # noqa
+         IWidgetsLayer)
+@implementer(IFieldWidget)
+def CarouselBackgroundLinkWidget(field, request):
+    widget = FieldWidget(field, RelatedItemsWidget(request))
+    widget.vocabulary = 'plone.app.vocabularies.Catalog'
+    return widget
+
+
+@adapter(getSpecification(ICarouselItemBehavior['carousel_link']),
+         IWidgetsLayer)
+@implementer(IFieldWidget)
+def CarouselLinkWidget(field, request):
+    widget = FieldWidget(field, RelatedItemsWidget(request))
+    widget.vocabulary = 'plone.app.vocabularies.Catalog'
+    widget.pattern_options.setdefault('selectableTypes', ['Image'])
+    widget.pattern_options.setdefault('maximumSelectionSize', 1)
+    return widget
+
+
+@adapter(getSpecification(ICarouselPortlet['collection_reference']),
+         IWidgetsLayer)
+@implementer(IFieldWidget)
+def CarouselCollectionReferenceWidget(field, request):
+    widget = FieldWidget(field, RelatedItemsWidget(request))
+    widget.vocabulary = 'plone.app.vocabularies.Catalog'
+    widget.pattern_options.setdefault('selectableTypes',
+                                      ['Collection', 'Topic'])
+    widget.pattern_options.setdefault('maximumSelectionSize', 1)
+    return widget
+
+
+@adapter(getSpecification(ICarouselPortlet['references']),
+         IWidgetsLayer)
+@implementer(IFieldWidget)
+def CarouselReferencesWidget(field, request):
+    widget = FieldWidget(field, RelatedItemsWidget(request))
+    widget.vocabulary = 'plone.app.vocabularies.Catalog'
+    return widget

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(name='collective.portlet.carousel',
       include_package_data=True,
       zip_safe=True,
       install_requires=[
-          'distribute',
+          'setuptools',
           'collective.panels',
           'plone.app.portlets',
           # -*- Extra requirements: -*-


### PR DESCRIPTION
- update to Dexterity 2.x (this pull is currently incompatible with 1.x)
- fix distribute dependency with setuptools dependency
- add to use relateditemswidget from p.a.widgets
